### PR TITLE
Improve compatibility with other mods

### DIFF
--- a/src/main/java/de/maxhenkel/camerautils/mixin/GameRendererMixin.java
+++ b/src/main/java/de/maxhenkel/camerautils/mixin/GameRendererMixin.java
@@ -9,8 +9,7 @@ import net.minecraft.client.renderer.GameRenderer;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.*;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(GameRenderer.class)
@@ -25,29 +24,17 @@ public abstract class GameRendererMixin {
     @Shadow
     private float oldFov;
 
-    @Inject(at = @At("HEAD"), method = "tickFov", cancellable = true)
+    @Inject(at = @At("HEAD"), method = "tickFov")
     private void tickFov(CallbackInfo info) {
-        info.cancel();
         if (CameraUtils.ZOOM_TRACK != null) {
             CameraUtils.ZOOM_TRACK.tick();
         }
-
-        float newFOV = 1F;
-        if (minecraft.getCameraEntity() instanceof AbstractClientPlayer) {
-            AbstractClientPlayer abstractClientPlayer = (AbstractClientPlayer) minecraft.getCameraEntity();
-            newFOV = abstractClientPlayer.getFieldOfViewModifier();
-        }
-
-        oldFov = fov;
-        fov += (newFOV - fov) * 0.5F;
-        if (fov > 2F) {
-            fov = 2F;
-        }
-
-        if (fov < 0.01F) {
-            fov = 0.01F;
-        }
     }
+    @ModifyConstant(method = "tickFov", constant = @Constant(floatValue = 1.5F))
+    private float increaaseFloatValue(float constant) {
+        return 2.0F;
+    }
+
 
     @Inject(at = @At("HEAD"), method = "bobView", cancellable = true)
     private void bobView(PoseStack poseStack, float f, CallbackInfo info) {


### PR DESCRIPTION
Changed the method of modifying the `tickFov()` method to be less invasive. The previous implementation hard coded the entire changed `tickFov()` method, thus making it hard for other developers that want to acccess this method to change anything. The new method only modifies the specific parts that are actually different from the vanilla code.